### PR TITLE
fix: fixed crash in Node 22+ by using Buffer instead of {} with EnumDisplaySettingsA

### DIFF
--- a/lib/commands/system.ts
+++ b/lib/commands/system.ts
@@ -3,5 +3,5 @@ import { NovaWindowsDriver } from '../driver';
 import { getDisplayOrientation } from '../winapi/user32';
 
 export function getOrientation(this: NovaWindowsDriver): Orientation {
-    return getDisplayOrientation() % 2 ? 'PORTRAIT' : 'LANDSCAPE';
+    return getDisplayOrientation();
 }

--- a/lib/winapi/user32.ts
+++ b/lib/winapi/user32.ts
@@ -652,7 +652,7 @@ async function sendMouseMoveInput(args: { x: number, y: number, relative: boolea
     let { x, y, easingFunction, relative } = args;
     const screenResolutionAndRefreshRate = getScreenResolutionAndRefreshRate();
     const [, , refreshRate] = screenResolutionAndRefreshRate;
-    const updateInterval = 1000 / refreshRate; // this is not used if refreshRate is null
+    const updateInterval = 1000 / refreshRate;
     const iterations = Math.max(Math.floor(duration / updateInterval), 1);
 
     const cursorPosition = {


### PR DESCRIPTION
## Proposed changes

This PR fixes a crash that occurs in Node.js 22+ when calling the Windows API function `EnumDisplaySettingsA` via `koffi` with an empty object (`{}`). In previous Node versions, passing an object that gets populated with fields worked fine, but starting from Node 22, this behavior causes a native crash. This change replaces the object with a `Buffer`, which acts as a workaround for changes in Node 22+ and prevents the native crash.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
