### PR TITLE
fix: set shouldCloseApp's default value to true

### DIFF
--- a/lib/driver.ts
+++ b/lib/driver.ts
@@ -173,6 +173,9 @@ export class NovaWindowsDriver extends BaseDriver<NovaWindowsDriverConstraints, 
             if (caps.app && caps.appTopLevelWindow) {
                 throw new errors.InvalidArgumentError('Invalid capabilities. Specify either app or appTopLevelWindow.');
             }
+            if (this.caps.shouldCloseApp === undefined) {
+                this.caps.shouldCloseApp = true; // set default value
+            }
 
             await this.startPowerShellSession();
 


### PR DESCRIPTION
## Proposed changes

Set the default value of `shouldCloseApp` to `true`, matching the documentation and aligning with the default behavior in WinAppDriver / appium-windows-driver.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
