### PR TITLE
Add support for close app and launch app

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,11 +532,58 @@ To be implemented.
 
 ### windows: launchApp
 
-To be implemented.
+Launches an application and waits for it to start. Supports both classic Win32 apps (by path) and UWP apps (by App User Model ID).
+
+#### Arguments
+
+Name | Type | Required | Description | Example
+--- | --- | --- | --- | ---
+app | string | yes | Path to the executable or UWP App User Model ID (AUMID). Classic format: `C:\Path\To\app.exe`. UWP format: `Microsoft.WindowsCalculator_8wekyb3d8bbwe!App` | notepad.exe
+appArguments | string | no | Command-line arguments to pass to the application. | --some-flag
+
+#### Example
+
+```csharp
+// Launch Notepad
+driver.ExecuteScript("windows: launchApp", new Dictionary<string, object> { { "app", "notepad.exe" } });
+
+// Launch Calculator (UWP)
+driver.ExecuteScript("windows: launchApp", new Dictionary<string, object> {
+    { "app", "Microsoft.WindowsCalculator_8wekyb3d8bbwe!App" }
+});
+
+// Launch with arguments
+driver.ExecuteScript("windows: launchApp", new Dictionary<string, object> {
+    { "app", "notepad.exe" },
+    { "appArguments", "C:\\path\\to\\file.txt" }
+});
+```
 
 ### windows: closeApp
 
-To be implemented.
+Terminates a running application by process ID, process name, or window handle. All three methods force-kill the process (same outcome). For graceful window close, use `windows: close` with an element. Exactly one identifier must be provided.
+
+#### Arguments
+
+Name | Type | Required | Description | Example
+--- | --- | --- | --- | ---
+processId | number | no | Process ID (PID) of the application to terminate. Uses `Stop-Process -Id`. | 12345
+processName | string | no | Process name (e.g. executable name without extension). Terminates all processes with that name. Uses `Stop-Process -Name`. | notepad
+windowHandle | string or number | no | Native window handle of the application window. Resolves the window to its process ID, then terminates it via `Stop-Process -Id`. Accepts hex string (e.g. `"0x12345678"`) or number. | 0x12345678
+
+
+#### Example
+
+```csharp
+// Close by process ID
+driver.ExecuteScript("windows: closeApp", new Dictionary<string, object> { { "processId", 12345 } });
+
+// Close by process name (e.g. all Notepad instances)
+driver.ExecuteScript("windows: closeApp", new Dictionary<string, object> { { "processName", "notepad" } });
+
+// Close by window handle (e.g. from getWindowHandle)
+driver.ExecuteScript("windows: closeApp", new Dictionary<string, object> { { "windowHandle", "0x12345678" } });
+```
 
 ### windows: clickAndDrag
 

--- a/lib/commands/extension.ts
+++ b/lib/commands/extension.ts
@@ -1,3 +1,4 @@
+import { normalize } from 'node:path';
 import { W3C_ELEMENT_KEY, errors } from '@appium/base-driver';
 import { Element, Rect } from '@appium/types';
 import { NovaWindowsDriver } from '../driver';
@@ -16,6 +17,7 @@ import {
     AutomationElement,
     AutomationElementMode,
     FoundAutomationElement,
+    PSInt32,
     PSInt32Array,
     Property,
     PropertyCondition,
@@ -47,6 +49,8 @@ const EXTENSION_COMMANDS = Object.freeze({
     minimize: 'patternMinimize',
     restore: 'patternRestore',
     close: 'patternClose',
+    closeApp: 'closeApp',
+    launchApp: 'launchApp',
     keys: 'executeKeys',
     click: 'executeClick',
     hover: 'executeHover',
@@ -242,6 +246,71 @@ export async function patternRestore(this: NovaWindowsDriver, element: Element):
 
 export async function patternClose(this: NovaWindowsDriver, element: Element): Promise<void> {
     await this.sendPowerShellCommand(new FoundAutomationElement(element[W3C_ELEMENT_KEY]).buildCloseCommand());
+}
+
+export async function closeApp(this: NovaWindowsDriver, args: {
+    processId?: number,
+    processName?: string,
+    windowHandle?: string | number,
+}): Promise<void> {
+    const { processId, processName, windowHandle } = args ?? {};
+    const provided = [processId, processName, windowHandle].filter((v) => v != null).length;
+
+    if (provided !== 1) {
+        throw new errors.InvalidArgumentError(
+            'Exactly one of processId, processName, or windowHandle must be provided.'
+        );
+    }
+
+    if (processId != null) {
+        await this.sendPowerShellCommand(`Stop-Process -Id ${processId}`);
+        return;
+    }
+
+    if (processName != null) {
+        await this.sendPowerShellCommand(`Stop-Process -Name '${processName}'`);
+        return;
+    }
+
+    if (windowHandle != null) {
+        const handle = typeof windowHandle === 'string' ? parseInt(windowHandle, 16) : windowHandle;
+        const condition = new PropertyCondition(Property.NATIVE_WINDOW_HANDLE, new PSInt32(handle));
+        const elementId = await this.sendPowerShellCommand(
+            AutomationElement.rootElement
+                .findFirst(TreeScope.CHILDREN_OR_SELF, condition)
+                .buildCommand()
+        );
+        if (!elementId?.trim()) {
+            throw new errors.NoSuchWindowError(`No window found with handle ${windowHandle}`);
+        }
+        const processId = await this.sendPowerShellCommand(
+            new FoundAutomationElement(elementId.trim()).buildGetPropertyCommand(Property.PROCESS_ID)
+        );
+        if (!processId?.trim()) {
+            throw new errors.UnknownError(`Could not get process ID for window handle ${windowHandle}`);
+        }
+        await this.sendPowerShellCommand(`Stop-Process -Id ${processId.trim()}`);
+    }
+}
+
+export async function launchApp(this: NovaWindowsDriver, args: {
+    app: string,
+    appArguments?: string,
+}): Promise<void> {
+    if (!args || typeof args !== 'object' || !args.app) {
+        throw new errors.InvalidArgumentError("'app' must be provided.");
+    }
+
+    const { app, appArguments } = args;
+    if (app.includes('!') && app.includes('_') && !(app.includes('/') || app.includes('\\'))) {
+        this.log.debug('Detected app path to be in the UWP format.');
+        await this.sendPowerShellCommand(/* ps1 */ `Start-Process 'explorer.exe' 'shell:AppsFolder\\${app}'${appArguments ? ` -ArgumentList '${appArguments}'` : ''}`);
+    } else {
+        this.log.debug('Detected app path to be in the classic format.');
+        const normalizedPath = normalize(app);
+        await this.sendPowerShellCommand(/* ps1 */ `Start-Process '${normalizedPath}'${appArguments ? ` -ArgumentList '${appArguments}'` : ''}`);
+    }
+    await sleep(1500); // Wait for the app to start
 }
 
 export async function focusElement(this: NovaWindowsDriver, element: Element): Promise<void> {


### PR DESCRIPTION
## Proposed changes

Implemented missing features to close and launch an app.
Close accepts one of the following: processId, processName or windowHandle. And it kills the process, that's to differentiate closing the app from closing the window.
Start/Launch accepts both UWP and classic path,

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [ ] I have signed the CLA
- [x] Lint passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
