### PR TITLE
Fix/windows 10 scaling

### DIFF
--- a/lib/commands/app.ts
+++ b/lib/commands/app.ts
@@ -36,6 +36,16 @@ const GET_PAGE_SOURCE_COMMAND = pwsh$ /* ps1 */ `
 `;
 
 const GET_SCREENSHOT_COMMAND = pwsh /* ps1 */ `
+    if (-not ([System.Management.Automation.PSTypeName]'DpiAwareness').Type) {
+        Add-Type @"
+        using System.Runtime.InteropServices;
+        public class DpiAwareness {
+            [DllImport("user32.dll")] public static extern bool SetProcessDPIAware();
+        }
+"@
+    }
+    [DpiAwareness]::SetProcessDPIAware() | Out-Null
+
     if ($rootElement -eq $null) {
         $bitmap = New-Object Drawing.Bitmap 1,1
         $stream = New-Object IO.MemoryStream

--- a/test/e2e/window.e2e.ts
+++ b/test/e2e/window.e2e.ts
@@ -103,4 +103,28 @@ describe('Window and app management commands', () => {
             expect(buffer[3]).toBe(0x47); // G
         });
     });
+
+    describe('DPI scaling consistency', () => {
+        it('screenshot pixel dimensions match getWindowRect width and height', async () => {
+            const rect = await calc.getWindowRect();
+            const screenshot = await calc.takeScreenshot();
+            const buffer = Buffer.from(screenshot, 'base64');
+
+            // PNG IHDR chunk: width at bytes 16-19, height at 20-23 (big-endian uint32)
+            const pngWidth = buffer.readUInt32BE(16);
+            const pngHeight = buffer.readUInt32BE(20);
+
+            expect(pngWidth).toBe(rect.width);
+            expect(pngHeight).toBe(rect.height);
+        });
+
+        it('element rect fits within window bounds', async () => {
+            const windowRect = await calc.getWindowRect();
+            const btn = await calc.$('~num1Button');
+            const btnSize = await btn.getSize();
+
+            expect(btnSize.width).toBeLessThanOrEqual(windowRect.width);
+            expect(btnSize.height).toBeLessThanOrEqual(windowRect.height);
+        });
+    });
 });


### PR DESCRIPTION
## Proposed changes

This is a simple fix for the scaling problem reported in issue #45
It makes the screenshot command aware of DPS. There's also an added end to end test that checks if the coordinates match.
The problem isn't reproducible in Windows 11 - my machine - so I need the fix to be tested in a Windows 10 machine before merging. Can you do that @teo-nikolov ?

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [ ] I have signed the CLA
- [x] Lint passes locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

