### PR TITLE
chore: bump deps to resolve security advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "appium": "^3.0.0-rc.2"
   },
   "dependencies": {
-    "@appium/base-driver": "^10.1.0",
-    "appium-chromedriver": "^8.2.21",
+    "@appium/base-driver": "^10.6.0",
+    "appium-chromedriver": "^8.4.5",
     "bezier-easing": "^2.1.0",
     "koffi": "^2.14.1",
     "xpath-analyzer": "^3.0.1"


### PR DESCRIPTION
Proposed changes

This PR updates only direct dependencies to resolve known security issues in transitive packages. No source code changes are included — this is purely a dependency bump to safe versions of packages we directly control.

Updated direct dependencies:

@appium/base-driver → 10.6.0
appium-chromedriver → 8.4.5