### PR TITLE
fix: return whether the window was actually brought to the foreground

### DIFF
--- a/lib/winapi/user32.ts
+++ b/lib/winapi/user32.ts
@@ -825,13 +825,23 @@ export function getWindowAllHandlesForProcessIds(processIds: number[]): number[]
 }
 
 export function trySetForegroundWindow(windowHandle: number): boolean {
-    return EnumWindows((hWnd) => {
+    let succeeded = false;
+
+    EnumWindows((hWnd) => {
         if (windowHandle === Number(address(hWnd))) {
-            return SetForegroundWindow(hWnd);
+            // Save whether SetForegroundWindow succeeded
+            succeeded = SetForegroundWindow(hWnd);
+
+            // Stop enumerating
+            return false;
         }
 
-        return false;
+        // Continue enumerating
+        return true;
     }, 0);
+
+    // Return true if SetForegroundWindow was invoked successfully
+    return succeeded;
 }
 
 export function sendKeyboardEvents(inputs: (KeyboardEvent['u']['ki'])[]): number {


### PR DESCRIPTION
## Proposed changes

trySetForegroundWindow returned EnumWindows' own result, which answers a different question than the caller asks. EnumWindows returns false whenever a callback halts enumeration - which is exactly what locating the target window does - so a successful search reported failure.

1.4.2 returned false for a real window and true for a bogus one. The fix in 1.4.3 removed that inversion but returned SetForegroundWindow's result from the callback, where the return value is EnumWindows' continue/stop signal rather than a success indicator. Non-matching windows now answer "stop", so enumeration halts at the first window examined and the target is normally never reached; and on the rare occasion it is reached, a successful call answers "continue", so enumeration proceeds and EnumWindows still returns false. Measured on a desktop of 365 top-level windows, enumeration visited exactly one and the target window was never seen.

The observable effect is unchanged across both releases: the function cannot return true for a real window, so attachToApplicationWindow always takes its focusElement fallback. UIA SetFocus() throws when the window is already in the foreground - the normal case immediately after launching an app - and the throw is swallowed, so the driver exhausts its 20 retries and fails with "Failed to locate window of the app."

Keep the callback's return value meaning continue/stop, capture the outcome of SetForegroundWindow in a closure variable, and discard EnumWindows' result. This restores the pre-1.4.1 behavior. SetForegroundWindow reports success when the window is already foreground, so the fallback is correctly skipped in that case.

Verified without an Appium session: trySetForegroundWindow now returns true for a real window and false for a bogus handle, where 1.4.3 returns false for both. The full suite (287 tests), lint and build pass, and a downstream Appium integration suite that failed 100% on 1.4.2/1.4.3 now passes 10/10 against a local install of this build.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The failure is in the Win32 FFI wrapper, and unfortunately the test suite is written to mock out the Win32 FFI - so the failure is exactly in the area that the test suite mocks.

Fixes #91